### PR TITLE
restrict public_suffix dependency version to 1.4.x

### DIFF
--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "postrank-uri"
 
   s.add_dependency "addressable",   "~> 2.3.0"
-  s.add_dependency "public_suffix", "~> 1.1"
+  s.add_dependency "public_suffix", "~> 1.4.0"
 
   s.add_development_dependency "rspec"
 


### PR DESCRIPTION
  v 1.5.0 of public_suffix drops support for ruby < 2.0 (consequently for jruby 1.7.x)
